### PR TITLE
fixed XMPPHP for PHP7

### DIFF
--- a/XMPPHP/Roster.php
+++ b/XMPPHP/Roster.php
@@ -118,7 +118,7 @@ class Roster {
 	 * @param string $status
 	*/
 	public function setPresence($presence, $priority, $show, $status) {
-		list($jid, $resource) = split("/", $presence);
+		list($jid, $resource) = explode("/", $presence);
 		if ($show != 'unavailable') {
 			if (!$this->isContact($jid)) {
 				$this->addContact($jid, 'not-in-roster');
@@ -137,7 +137,7 @@ class Roster {
 	 * @param string $jid
 	 */
 	public function getPresence($jid) {
-		$split = split("/", $jid);
+		$split = explode("/", $jid);
 		$jid = $split[0];
 		if($this->isContact($jid)) {
 			$current = array('resource' => '', 'active' => '', 'priority' => -129, 'show' => '', 'status' => ''); //Priorities can only be -128 = 127

--- a/XMPPHP/XMLStream.php
+++ b/XMPPHP/XMLStream.php
@@ -263,7 +263,7 @@ class XMPPHP_XMLStream {
 			$ns_tags = array($xpath);
 		}
 		foreach($ns_tags as $ns_tag) {
-			list($l, $r) = split("}", $ns_tag);
+			list($l, $r) = explode("}", $ns_tag);
 			if ($r != null) {
 				$xpart = array(substr($l, 1), $r);
 			} else {
@@ -564,7 +564,7 @@ class XMPPHP_XMLStream {
 						if ($searchxml !== null) {
 							if($handler[2] === null) $handler[2] = $this;
 							$this->log->log("Calling {$handler[1]}",  XMPPHP_Log::LEVEL_DEBUG);
-							$handler[2]->$handler[1]($this->xmlobj[2]);
+							$handler[2]->{$handler[1]}($this->xmlobj[2]);
 						}
 					}
 				}
@@ -578,13 +578,13 @@ class XMPPHP_XMLStream {
 				if($searchxml !== null and $searchxml->name == $handler[0] and ($searchxml->ns == $handler[1] or (!$handler[1] and $searchxml->ns == $this->default_ns))) {
 					if($handler[3] === null) $handler[3] = $this;
 					$this->log->log("Calling {$handler[2]}",  XMPPHP_Log::LEVEL_DEBUG);
-					$handler[3]->$handler[2]($this->xmlobj[2]);
+					$handler[3]->{$handler[2]}($this->xmlobj[2]);
 				}
 			}
 			foreach($this->idhandlers as $id => $handler) {
 				if(array_key_exists('id', $this->xmlobj[2]->attrs) and $this->xmlobj[2]->attrs['id'] == $id) {
 					if($handler[1] === null) $handler[1] = $this;
-					$handler[1]->$handler[0]($this->xmlobj[2]);
+					$handler[1]->{$handler[0]}($this->xmlobj[2]);
 					#id handlers are only used once
 					unset($this->idhandlers[$id]);
 					break;
@@ -640,7 +640,7 @@ class XMPPHP_XMLStream {
 				if($handler[2] === null) {
 					$handler[2] = $this;
 				}
-				$handler[2]->$handler[1]($payload);
+				$handler[2]->{$handler[1]}($payload);
 			}
 		}
 		foreach($this->until as $key => $until) {


### PR DESCRIPTION
Bundled library XMPPHP doesn't work with PHP7.
A patch like [this](https://git.gnu.io/gnu/gnu-social/commit/af281606794358b05199f5b50fefd7fc4ec5b52a) is needed.